### PR TITLE
fixed timing issue with Service and ListenerRule by DependsOn

### DIFF
--- a/services/product-service/service.yaml
+++ b/services/product-service/service.yaml
@@ -29,6 +29,7 @@ Resources:
 
     Service: 
         Type: AWS::ECS::Service
+        DependsOn: ListenerRule
         Properties: 
             Cluster: !Ref Cluster
             Role: !Ref ServiceRole

--- a/services/website-service/service.yaml
+++ b/services/website-service/service.yaml
@@ -34,6 +34,7 @@ Resources:
 
     Service: 
         Type: AWS::ECS::Service
+        DependsOn: ListenerRule
         Properties: 
             Cluster: !Ref Cluster
             Role: !Ref ServiceRole


### PR DESCRIPTION
There is sometimes a timing issue where the Service will be created before the ListenerRule. When this happens the Stack will fail to create with error "The target group with targetGroupArn arn:xxx does not have an associated load balancer." when deploying.