### PR TITLE
Include environment name in target group name

### DIFF
--- a/infrastructure/load-balancers.yaml
+++ b/infrastructure/load-balancers.yaml
@@ -49,7 +49,7 @@ Resources:
     DefaultTargetGroup:
         Type: AWS::ElasticLoadBalancingV2::TargetGroup
         Properties:
-            Name: default
+            Name: !Sub ${EnvironmentName}-default
             VpcId: !Ref VPC
             Port: 80
             Protocol: HTTP


### PR DESCRIPTION
Cloud Formation gets very confused if multiple stacks reference a target
group with the same name, leading to aborted updates and failure to
delete stacks. To prevent this prefix the target group name with the
stack name.