### PR TITLE
ValidationError: Resource ContainerInstances does not exist

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -131,7 +131,7 @@ Resources:
                             content: !Sub |
                                 [cfn-auto-reloader-hook]
                                 triggers=post.update
-                                path=Resources.ContainerInstances.Metadata.AWS::CloudFormation::Init
+                                path=Resources.ECSLaunchConfiguration.Metadata.AWS::CloudFormation::Init
                                 action=/opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
 
                     services: 


### PR DESCRIPTION
I'm seeing the following error in `/var/log/cfn-hup.log` and `cfn-wire.log` after the container instances have booted:

```
AwsQueryError: [Errno 400] ValidationError: Resource ContainerInstances does not exist for stack arn:aws:cloudformation:…
```

This seems to be caused by `infrastructure/ecs-cluster.yaml`:
```
"/etc/cfn/hooks.d/cfn-auto-reloader.conf":
    content: !Sub |
        [cfn-auto-reloader-hook]
        triggers=post.update
        path=Resources.ContainerInstances.Metadata.AWS::CloudFormation::Init
        action=/opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
```

Perhaps it should be `Resources.ECSLaunchConfiguration.Metadata.…` instead of `Resources.ContainerInstances.Metadata.…`?