### PR TITLE
updated ecs-cluster to ensure processes are suspended

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -94,6 +94,12 @@ Resources:
                 MinInstancesInService: 1
                 MaxBatchSize: 1
                 PauseTime: PT15M
+                SuspendProcesses:
+                  - HealthCheck
+                  - ReplaceUnhealthy
+                  - AZRebalance
+                  - AlarmNotification
+                  - ScheduledActions
                 WaitOnResourceSignals: true
         
     ECSLaunchConfiguration:


### PR DESCRIPTION
Without this, `Terminate` and `Launch` are suspended, which makes the autoscaling rolling update impossible