### PR TITLE
Add ECS instance access by including SSM to address issue #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can launch this CloudFormation stack in the US East (N. Virginia) Region in 
 The repository consists of a set of nested templates that deploy the following:
 
  - A tiered [VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Introduction.html) with public and private subnets, spanning an AWS region.
- - A highly available ECS cluster deployed across two [Availability Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) in an [Auto Scaling](https://aws.amazon.com/autoscaling/) group.
+ - A highly available ECS cluster deployed across two [Availability Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) in an [Auto Scaling](https://aws.amazon.com/autoscaling/) group and that are AWS SSM enabled.
  - A pair of [NAT gateways](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html) (one in each zone) to handle outbound traffic.
  - Two interconnecting microservices deployed as [ECS services](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) (website-service and product-service). 
  - An [Application Load Balancer (ALB)](https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/) to the public subnets to handle inbound traffic.
@@ -48,13 +48,15 @@ The templates below are included in this repository and reference architecture:
 | [infrastructure/vpc.yaml](infrastructure/vpc.yaml) | This template deploys a VPC with a pair of public and private subnets spread across two Availability Zones. It deploys an [Internet gateway](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Internet_Gateway.html), with a default route on the public subnets. It deploys a pair of NAT gateways (one in each zone), and default routes for them in the private subnets. |
 | [infrastructure/security-groups.yaml](infrastructure/security-groups.yaml) | This template contains the [security groups](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html) required by the entire stack. They are created in a separate nested template, so that they can be referenced by all of the other nested templates. |
 | [infrastructure/load-balancers.yaml](infrastructure/load-balancers.yaml) | This template deploys an ALB to the public subnets, which exposes the various ECS services. It is created in in a separate nested template, so that it can be referenced by all of the other nested templates and so that the various ECS services can register with it. |
-| [infrastructure/ecs-cluster.yaml](infrastructure/ecs-cluster.yaml) | This template deploys an ECS cluster to the private subnets using an Auto Scaling group. |
+| [infrastructure/ecs-cluster.yaml](infrastructure/ecs-cluster.yaml) | This template deploys an ECS cluster to the private subnets using an Auto Scaling group and installs the AWS SSM agent with related policy requirements. |
 | [services/product-service/service.yaml](services/product-service/service.yaml) | This is an example of a long-running ECS service that serves a JSON API of products. For the full source for the service, see [services/product-service/src](services/product-service/src).|
 | [services/website-service/service.yaml](services/website-service/service.yaml) | This is an example of a long-running ECS service that needs to connect to another service (product-service) via the load-balanced URL. We use an environment variable to pass the product-service URL to the containers. For the full source for this service, see [services/website-service/src](services/website-service/src). |
 
 After the CloudFormation templates have been deployed, the [stack outputs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html) contain a link to the load-balanced URLs for each of the deployed microservices.
 
 ![stack-outputs](images/stack-outputs.png)
+
+The ECS instances should also appear in the Managed Instances section of the EC2 console.
 
 ## How do I...?
 
@@ -182,6 +184,10 @@ Service:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
 ```
+
+### Use the SSM Run Command function to see details in the ECS instances
+
+The AWS SSM Run Command function, in the EC2 console, can be used to execute commands at the shell on the ECS instances. These can be helpful for examining the installed configuration of the instances without requiring direct access to them.
 
 ### Add a new item to this list
 

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -113,6 +113,7 @@ Resources:
             UserData: 
                 "Fn::Base64": !Sub |
                     #!/bin/bash
+                    yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
                     yum install -y aws-cfn-bootstrap
                     /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
                     /opt/aws/bin/cfn-signal -e $? --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSAutoScalingGroup
@@ -191,7 +192,41 @@ Resources:
                                 "ecr:BatchCheckLayerAvailability",
                                 "ecr:BatchGetImage",
                                 "ecr:GetDownloadUrlForLayer",
-                                "ecr:GetAuthorizationToken"
+                                "ecr:GetAuthorizationToken",
+                                "ssm:DescribeAssociation",
+                                "ssm:GetDeployablePatchSnapshotForInstance",
+                                "ssm:GetDocument",
+                                "ssm:GetManifest",
+                                "ssm:GetParameters",
+                                "ssm:ListAssociations",
+                                "ssm:ListInstanceAssociations",
+                                "ssm:PutInventory",
+                                "ssm:PutComplianceItems",
+                                "ssm:PutConfigurePackageResult",
+                                "ssm:UpdateAssociationStatus",
+                                "ssm:UpdateInstanceAssociationStatus",
+                                "ssm:UpdateInstanceInformation",
+                                "ec2messages:AcknowledgeMessage",
+                                "ec2messages:DeleteMessage",
+                                "ec2messages:FailMessage",
+                                "ec2messages:GetEndpoint",
+                                "ec2messages:GetMessages",
+                                "ec2messages:SendReply",
+                                "cloudwatch:PutMetricData",
+                                "ec2:DescribeInstanceStatus",
+                                "ds:CreateComputer",
+                                "ds:DescribeDirectories",
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:DescribeLogGroups",
+                                "logs:DescribeLogStreams",
+                                "logs:PutLogEvents",
+                                "s3:PutObject",
+                                "s3:GetObject",
+                                "s3:AbortMultipartUpload",
+                                "s3:ListMultipartUploadParts",
+                                "s3:ListBucket",
+                                "s3:ListBucketMultipartUploads"
                             ],
                             "Resource": "*"
                         }]

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -45,35 +45,35 @@ Mappings:
 
     AWSRegionToAMI:
         us-east-2:
-            AMI: ami-13af8476
+            AMI: ami-ce1c36ab
         us-east-1:
-            AMI: ami-ba722dc0
+            AMI: ami-28456852
         us-west-2:
-            AMI: ami-c9c87cb1
+            AMI: ami-decc7fa6
         us-west-1:
-            AMI: ami-9df0f0fd
+            AMI: ami-74262414
         eu-west-3:
-            AMI: ami-5e02b523
+            AMI: ami-9aef59e7
         eu-west-2:
-            AMI: ami-4d809829
+            AMI: ami-67cbd003
         eu-west-1:
-            AMI: ami-acb020d5
+            AMI: ami-1d46df64
         eu-central-1:
-            AMI: ami-eacf5d85
+            AMI: ami-509a053f
         ap-northeast-2:
-            AMI: ami-59b71737
+            AMI: ami-c212b2ac
         ap-northeast-1:
-            AMI: ami-72f36a14
+            AMI: ami-872c4ae1
         ap-southeast-2:
-            AMI: ami-7aa15c18
+            AMI: ami-58bb443a
         ap-southeast-1:
-            AMI: ami-e782f29b
+            AMI: ami-910d72ed
         ca-central-1:
-            AMI: ami-9afc79fe
+            AMI: ami-435bde27
         ap-south-1:
-            AMI: ami-f4db8f9b
+            AMI: ami-00491f6f
         sa-east-1:
-            AMI: ami-49256725
+            AMI: ami-af521fc3
 
 Resources:
 

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -45,27 +45,35 @@ Mappings:
 
     AWSRegionToAMI:
         us-east-2:
-            AMI: ami-1c002379
+            AMI: ami-13af8476
         us-east-1:
-            AMI: ami-9eb4b1e5
+            AMI: ami-ba722dc0
         us-west-2:
-            AMI: ami-1d668865
+            AMI: ami-c9c87cb1
         us-west-1:
-            AMI: ami-4a2c192a
+            AMI: ami-9df0f0fd
+        eu-west-3:
+            AMI: ami-5e02b523
         eu-west-2:
-            AMI: ami-cb1101af
+            AMI: ami-4d809829
         eu-west-1:
-            AMI: ami-8fcc32f6
+            AMI: ami-acb020d5
         eu-central-1:
-            AMI: ami-0460cb6b
+            AMI: ami-eacf5d85
+        ap-northeast-2:
+            AMI: ami-59b71737
         ap-northeast-1:
-            AMI: ami-b743bed1
+            AMI: ami-72f36a14
         ap-southeast-2:
-            AMI: ami-c1a6bda2
+            AMI: ami-7aa15c18
         ap-southeast-1:
-            AMI: ami-9d1f7efe
+            AMI: ami-e782f29b
         ca-central-1:
-            AMI: ami-b677c9d2
+            AMI: ami-9afc79fe
+        ap-south-1:
+            AMI: ami-f4db8f9b
+        sa-east-1:
+            AMI: ami-49256725
 
 Resources:
 

--- a/services/springboot-service1/service.yaml
+++ b/services/springboot-service1/service.yaml
@@ -1,0 +1,134 @@
+Description: >
+    This is an example of a long running ECS service using springboot.
+
+Parameters:
+
+    VPC:
+        Description: The VPC that the ECS cluster is deployed to
+        Type: AWS::EC2::VPC::Id
+
+    Cluster:
+        Description: Please provide the ECS Cluster ID that this service should run on
+        Type: String
+
+    DesiredCount:
+        Description: How many instances of this task should we run across our cluster?
+        Type: Number
+        Default: 2
+
+    Listener:
+        Description: The Application Load Balancer listener to register with
+        Type: String
+
+    Path:
+        Description: The path to register with the Application Load Balancer
+        Type: String
+        Default: /springboot1
+
+Resources:
+
+    Service:
+        Type: AWS::ECS::Service
+        DependsOn: ListenerRule
+        Properties:
+            Cluster: !Ref Cluster
+            Role: !Ref ServiceRole
+            DesiredCount: !Ref DesiredCount
+            TaskDefinition: !Ref TaskDefinition
+            LoadBalancers:
+                - ContainerName: "springboot-service"
+                  ContainerPort: 8080
+                  TargetGroupArn: !Ref TargetGroup
+
+    TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+            Family: springboot-service
+            ContainerDefinitions:
+                - Name: springboot-service
+                  Essential: true
+                  # Image: ninrod/springboot:test
+                  # Image: trinitronx/python-simplehttpserver:latest
+                  #Image: gregturn/gs-spring-boot-docker
+                  Image: dougtoppin/springboot1:latest
+                  #Command: [ 'java', '-jar', '/home/ninrod/delivery/ninrod-spring-boot-test-0.1.2.3.jar' ]
+                  Memory: 512
+                  PortMappings:
+                    - ContainerPort: 8080
+                  LogConfiguration:
+                    LogDriver: awslogs
+                    Options:
+                        awslogs-group: !Ref AWS::StackName
+                        awslogs-region: !Ref AWS::Region
+
+    CloudWatchLogsGroup:
+        Type: AWS::Logs::LogGroup
+        Properties:
+            LogGroupName: !Ref AWS::StackName
+            RetentionInDays: 365
+
+    TargetGroup:
+        Type: AWS::ElasticLoadBalancingV2::TargetGroup
+        Properties:
+            VpcId: !Ref VPC
+            Port: 80
+            Protocol: HTTP
+            Matcher:
+                HttpCode: 200-299
+            HealthCheckIntervalSeconds: 10
+            #HealthCheckPath: /health
+            HealthCheckPath: /springboot1
+            HealthCheckProtocol: HTTP
+            HealthCheckTimeoutSeconds: 5
+            HealthyThresholdCount: 2
+
+    ListenerRule:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref Listener
+            Priority: 3
+            Conditions:
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    # This IAM Role grants the service access to register/unregister with the
+    # Application Load Balancer (ALB). It is based on the default documented here:
+    # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
+    ServiceRole:
+        Type: AWS::IAM::Role
+        Properties:
+            RoleName: !Sub ecs-service-${AWS::StackName}
+            Path: /
+            AssumeRolePolicyDocument: |
+                {
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": { "Service": [ "ecs.amazonaws.com" ]},
+                        "Action": [ "sts:AssumeRole" ]
+                    }]
+                }
+            Policies:
+                - PolicyName: !Sub ecs-service-${AWS::StackName}
+                  PolicyDocument:
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                                "Effect": "Allow",
+                                "Action": [
+                                    "ec2:AuthorizeSecurityGroupIngress",
+                                    "ec2:Describe*",
+                                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                                    "elasticloadbalancing:Describe*",
+                                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                                    "elasticloadbalancing:DeregisterTargets",
+                                    "elasticloadbalancing:DescribeTargetGroups",
+                                    "elasticloadbalancing:DescribeTargetHealth",
+                                    "elasticloadbalancing:RegisterTargets"
+                                ],
+                                "Resource": "*"
+                        }]
+                    }

--- a/services/springboot-service2/service.yaml
+++ b/services/springboot-service2/service.yaml
@@ -1,0 +1,134 @@
+Description: >
+    This is an example of a long running ECS service using springboot.
+
+Parameters:
+
+    VPC:
+        Description: The VPC that the ECS cluster is deployed to
+        Type: AWS::EC2::VPC::Id
+
+    Cluster:
+        Description: Please provide the ECS Cluster ID that this service should run on
+        Type: String
+
+    DesiredCount:
+        Description: How many instances of this task should we run across our cluster?
+        Type: Number
+        Default: 2
+
+    Listener:
+        Description: The Application Load Balancer listener to register with
+        Type: String
+
+    Path:
+        Description: The path to register with the Application Load Balancer
+        Type: String
+        Default: /springboot2
+
+Resources:
+
+    Service:
+        Type: AWS::ECS::Service
+        DependsOn: ListenerRule
+        Properties:
+            Cluster: !Ref Cluster
+            Role: !Ref ServiceRole
+            DesiredCount: !Ref DesiredCount
+            TaskDefinition: !Ref TaskDefinition
+            LoadBalancers:
+                - ContainerName: "springboot-service"
+                  ContainerPort: 8080
+                  TargetGroupArn: !Ref TargetGroup
+
+    TaskDefinition:
+        Type: AWS::ECS::TaskDefinition
+        Properties:
+            Family: springboot-service
+            ContainerDefinitions:
+                - Name: springboot-service
+                  Essential: true
+                  # Image: ninrod/springboot:test
+                  # Image: trinitronx/python-simplehttpserver:latest
+                  #Image: gregturn/gs-spring-boot-docker
+                  Image: dougtoppin/springboot2:latest
+                  #Command: [ 'java', '-jar', '/home/ninrod/delivery/ninrod-spring-boot-test-0.1.2.3.jar' ]
+                  Memory: 512
+                  PortMappings:
+                    - ContainerPort: 8080
+                  LogConfiguration:
+                    LogDriver: awslogs
+                    Options:
+                        awslogs-group: !Ref AWS::StackName
+                        awslogs-region: !Ref AWS::Region
+
+    CloudWatchLogsGroup:
+        Type: AWS::Logs::LogGroup
+        Properties:
+            LogGroupName: !Ref AWS::StackName
+            RetentionInDays: 365
+
+    TargetGroup:
+        Type: AWS::ElasticLoadBalancingV2::TargetGroup
+        Properties:
+            VpcId: !Ref VPC
+            Port: 80
+            Protocol: HTTP
+            Matcher:
+                HttpCode: 200-299
+            HealthCheckIntervalSeconds: 10
+            #HealthCheckPath: /health
+            HealthCheckPath: /springboot2
+            HealthCheckProtocol: HTTP
+            HealthCheckTimeoutSeconds: 5
+            HealthyThresholdCount: 2
+
+    ListenerRule:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            ListenerArn: !Ref Listener
+            Priority: 4
+            Conditions:
+                - Field: path-pattern
+                  Values:
+                    - !Ref Path
+            Actions:
+                - TargetGroupArn: !Ref TargetGroup
+                  Type: forward
+
+    # This IAM Role grants the service access to register/unregister with the
+    # Application Load Balancer (ALB). It is based on the default documented here:
+    # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_IAM_role.html
+    ServiceRole:
+        Type: AWS::IAM::Role
+        Properties:
+            RoleName: !Sub ecs-service-${AWS::StackName}
+            Path: /
+            AssumeRolePolicyDocument: |
+                {
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": { "Service": [ "ecs.amazonaws.com" ]},
+                        "Action": [ "sts:AssumeRole" ]
+                    }]
+                }
+            Policies:
+                - PolicyName: !Sub ecs-service-${AWS::StackName}
+                  PolicyDocument:
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                                "Effect": "Allow",
+                                "Action": [
+                                    "ec2:AuthorizeSecurityGroupIngress",
+                                    "ec2:Describe*",
+                                    "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                                    "elasticloadbalancing:Describe*",
+                                    "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                                    "elasticloadbalancing:DeregisterTargets",
+                                    "elasticloadbalancing:DescribeTargetGroups",
+                                    "elasticloadbalancing:DescribeTargetHealth",
+                                    "elasticloadbalancing:RegisterTargets"
+                                ],
+                                "Resource": "*"
+                        }]
+                    }


### PR DESCRIPTION
To provide access to the ECS instances without including a bastion host I added support for SSM. This involved installing the SSM agent and adding policy changes to ecs-cluster.yaml

I do not know if there are more policy mods than are actually required. If you can identify any that are not necessary I will remove them.
