### PR TITLE
fix for Issue #38 by adding SSM support and description, update AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can launch this CloudFormation stack in the US East (N. Virginia) Region in 
 The repository consists of a set of nested templates that deploy the following:
 
  - A tiered [VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Introduction.html) with public and private subnets, spanning an AWS region.
- - A highly available ECS cluster deployed across two [Availability Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) in an [Auto Scaling](https://aws.amazon.com/autoscaling/) group.
+ - A highly available ECS cluster deployed across two [Availability Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) in an [Auto Scaling](https://aws.amazon.com/autoscaling/) group and that are AWS SSM enabled.
  - A pair of [NAT gateways](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html) (one in each zone) to handle outbound traffic.
  - Two interconnecting microservices deployed as [ECS services](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) (website-service and product-service). 
  - An [Application Load Balancer (ALB)](https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/) to the public subnets to handle inbound traffic.
@@ -48,13 +48,15 @@ The templates below are included in this repository and reference architecture:
 | [infrastructure/vpc.yaml](infrastructure/vpc.yaml) | This template deploys a VPC with a pair of public and private subnets spread across two Availability Zones. It deploys an [Internet gateway](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Internet_Gateway.html), with a default route on the public subnets. It deploys a pair of NAT gateways (one in each zone), and default routes for them in the private subnets. |
 | [infrastructure/security-groups.yaml](infrastructure/security-groups.yaml) | This template contains the [security groups](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html) required by the entire stack. They are created in a separate nested template, so that they can be referenced by all of the other nested templates. |
 | [infrastructure/load-balancers.yaml](infrastructure/load-balancers.yaml) | This template deploys an ALB to the public subnets, which exposes the various ECS services. It is created in in a separate nested template, so that it can be referenced by all of the other nested templates and so that the various ECS services can register with it. |
-| [infrastructure/ecs-cluster.yaml](infrastructure/ecs-cluster.yaml) | This template deploys an ECS cluster to the private subnets using an Auto Scaling group. |
+| [infrastructure/ecs-cluster.yaml](infrastructure/ecs-cluster.yaml) | This template deploys an ECS cluster to the private subnets using an Auto Scaling group and installs the AWS SSM agent with related policy requirements. |
 | [services/product-service/service.yaml](services/product-service/service.yaml) | This is an example of a long-running ECS service that serves a JSON API of products. For the full source for the service, see [services/product-service/src](services/product-service/src).|
 | [services/website-service/service.yaml](services/website-service/service.yaml) | This is an example of a long-running ECS service that needs to connect to another service (product-service) via the load-balanced URL. We use an environment variable to pass the product-service URL to the containers. For the full source for this service, see [services/website-service/src](services/website-service/src). |
 
 After the CloudFormation templates have been deployed, the [stack outputs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html) contain a link to the load-balanced URLs for each of the deployed microservices.
 
 ![stack-outputs](images/stack-outputs.png)
+
+The ECS instances should also appear in the Managed Instances section of the EC2 console.
 
 ## How do I...?
 
@@ -182,6 +184,10 @@ Service:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
 ```
+
+### Use the SSM Run Command function to see details in the ECS instances
+
+The AWS SSM Run Command function, in the EC2 console, can be used to execute commands at the shell on the ECS instances. These can be helpful for examining the installed configuration of the instances without requiring direct access to them.
 
 ### Add a new item to this list
 

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -113,6 +113,7 @@ Resources:
             UserData: 
                 "Fn::Base64": !Sub |
                     #!/bin/bash
+                    yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
                     yum install -y aws-cfn-bootstrap
                     /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
                     /opt/aws/bin/cfn-signal -e $? --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSAutoScalingGroup
@@ -191,7 +192,41 @@ Resources:
                                 "ecr:BatchCheckLayerAvailability",
                                 "ecr:BatchGetImage",
                                 "ecr:GetDownloadUrlForLayer",
-                                "ecr:GetAuthorizationToken"
+                                "ecr:GetAuthorizationToken",
+                                "ssm:DescribeAssociation",
+                                "ssm:GetDeployablePatchSnapshotForInstance",
+                                "ssm:GetDocument",
+                                "ssm:GetManifest",
+                                "ssm:GetParameters",
+                                "ssm:ListAssociations",
+                                "ssm:ListInstanceAssociations",
+                                "ssm:PutInventory",
+                                "ssm:PutComplianceItems",
+                                "ssm:PutConfigurePackageResult",
+                                "ssm:UpdateAssociationStatus",
+                                "ssm:UpdateInstanceAssociationStatus",
+                                "ssm:UpdateInstanceInformation",
+                                "ec2messages:AcknowledgeMessage",
+                                "ec2messages:DeleteMessage",
+                                "ec2messages:FailMessage",
+                                "ec2messages:GetEndpoint",
+                                "ec2messages:GetMessages",
+                                "ec2messages:SendReply",
+                                "cloudwatch:PutMetricData",
+                                "ec2:DescribeInstanceStatus",
+                                "ds:CreateComputer",
+                                "ds:DescribeDirectories",
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:DescribeLogGroups",
+                                "logs:DescribeLogStreams",
+                                "logs:PutLogEvents",
+                                "s3:PutObject",
+                                "s3:GetObject",
+                                "s3:AbortMultipartUpload",
+                                "s3:ListMultipartUploadParts",
+                                "s3:ListBucket",
+                                "s3:ListBucketMultipartUploads"
                             ],
                             "Resource": "*"
                         }]

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -32,12 +32,12 @@ Parameters:
 
 Mappings:
 
-    # These are the latest ECS optimized AMIs as of August 2017:
+    # These are the latest ECS optimized AMIs as of Jan 2018:
     #
-    #   amzn-ami-2017.03.f-amazon-ecs-optimized
-    #   ECS agent:    1.14.4
-    #   Docker:       17.03.2-ce
-    #   ecs-init:     1.14.4-1
+    #   amzn-ami-2017.09.g-amazon-ecs-optimized
+    #   ECS agent:    1.16.2
+    #   Docker:       17.09.1-ce
+    #   ecs-init:     1.16.2-1
     #
     # You can find the latest available on this page of our documentation:
     # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
@@ -45,35 +45,35 @@ Mappings:
 
     AWSRegionToAMI:
         us-east-2:
-            AMI: ami-13af8476
+            AMI: ami-ce1c36ab
         us-east-1:
-            AMI: ami-ba722dc0
+            AMI: ami-28456852
         us-west-2:
-            AMI: ami-c9c87cb1
+            AMI: ami-decc7fa6
         us-west-1:
-            AMI: ami-9df0f0fd
+            AMI: ami-74262414
         eu-west-3:
-            AMI: ami-5e02b523
+            AMI: ami-9aef59e7
         eu-west-2:
-            AMI: ami-4d809829
+            AMI: ami-67cbd003
         eu-west-1:
-            AMI: ami-acb020d5
+            AMI: ami-1d46df64
         eu-central-1:
-            AMI: ami-eacf5d85
+            AMI: ami-509a053f
         ap-northeast-2:
-            AMI: ami-59b71737
+            AMI: ami-c212b2ac
         ap-northeast-1:
-            AMI: ami-72f36a14
+            AMI: ami-872c4ae1
         ap-southeast-2:
-            AMI: ami-7aa15c18
+            AMI: ami-58bb443a
         ap-southeast-1:
-            AMI: ami-e782f29b
+            AMI: ami-910d72ed
         ca-central-1:
-            AMI: ami-9afc79fe
+            AMI: ami-435bde27
         ap-south-1:
-            AMI: ami-f4db8f9b
+            AMI: ami-00491f6f
         sa-east-1:
-            AMI: ami-49256725
+            AMI: ami-af521fc3
 
 Resources:
 

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -45,27 +45,35 @@ Mappings:
 
     AWSRegionToAMI:
         us-east-2:
-            AMI: ami-1c002379
+            AMI: ami-13af8476
         us-east-1:
-            AMI: ami-9eb4b1e5
+            AMI: ami-ba722dc0
         us-west-2:
-            AMI: ami-1d668865
+            AMI: ami-c9c87cb1
         us-west-1:
-            AMI: ami-4a2c192a
+            AMI: ami-9df0f0fd
+        eu-west-3:
+            AMI: ami-5e02b523
         eu-west-2:
-            AMI: ami-cb1101af
+            AMI: ami-4d809829
         eu-west-1:
-            AMI: ami-8fcc32f6
+            AMI: ami-acb020d5
         eu-central-1:
-            AMI: ami-0460cb6b
+            AMI: ami-eacf5d85
+        ap-northeast-2:
+            AMI: ami-59b71737
         ap-northeast-1:
-            AMI: ami-b743bed1
+            AMI: ami-72f36a14
         ap-southeast-2:
-            AMI: ami-c1a6bda2
+            AMI: ami-7aa15c18
         ap-southeast-1:
-            AMI: ami-9d1f7efe
+            AMI: ami-e782f29b
         ca-central-1:
-            AMI: ami-b677c9d2
+            AMI: ami-9afc79fe
+        ap-south-1:
+            AMI: ami-f4db8f9b
+        sa-east-1:
+            AMI: ami-49256725
 
 Resources:
 


### PR DESCRIPTION
Suggest using SSM to provide access to the ECS instances by using RunCommand. 

Changes are:
* Added SSM support by adding to ECS instance policy (ecs-cluster.yaml). Note that there may be more added to the policy than are required to enable RunCommand.
* Updated ecs-cluster.yaml to current AMI (amzn-ami-2017.09.g-amazon-ecs-optimized)
* Added SSM mention to README.md




