### PR TITLE
Add empty string argument to !GetAZs

### DIFF
--- a/infrastructure/vpc.yaml
+++ b/infrastructure/vpc.yaml
@@ -62,7 +62,7 @@ Resources:
         Type: AWS::EC2::Subnet
         Properties:
             VpcId: !Ref VPC
-            AvailabilityZone: !Select [ 0, !GetAZs ]
+            AvailabilityZone: !Select [ 0, !GetAZs '' ]
             CidrBlock: !Ref PublicSubnet1CIDR
             MapPublicIpOnLaunch: true
             Tags: 
@@ -73,7 +73,7 @@ Resources:
         Type: AWS::EC2::Subnet
         Properties:
             VpcId: !Ref VPC
-            AvailabilityZone: !Select [ 1, !GetAZs ]
+            AvailabilityZone: !Select [ 1, !GetAZs '' ]
             CidrBlock: !Ref PublicSubnet2CIDR
             MapPublicIpOnLaunch: true
             Tags: 
@@ -84,7 +84,7 @@ Resources:
         Type: AWS::EC2::Subnet
         Properties:
             VpcId: !Ref VPC
-            AvailabilityZone: !Select [ 0, !GetAZs ]
+            AvailabilityZone: !Select [ 0, !GetAZs '' ]
             CidrBlock: !Ref PrivateSubnet1CIDR
             MapPublicIpOnLaunch: false
             Tags: 
@@ -95,7 +95,7 @@ Resources:
         Type: AWS::EC2::Subnet
         Properties:
             VpcId: !Ref VPC
-            AvailabilityZone: !Select [ 1, !GetAZs ]
+            AvailabilityZone: !Select [ 1, !GetAZs '' ]
             CidrBlock: !Ref PrivateSubnet2CIDR
             MapPublicIpOnLaunch: false
             Tags: 


### PR DESCRIPTION
> Specifying an empty string is equivalent to specifying AWS::Region.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html

Including no value is ambiguous and some YAML parsers/validators will fail. This came up in a project I built for automating nested stack uploads to S3: https://github.com/bendrucker/cfn-nest/issues/2#issuecomment-361687447

Including the empty string is better aligned with the official CloudFormation docs and more friendly to third party utilities and validation tools that interpret those docs.