### PR TITLE
Enable DNS hostname

### DIFF
--- a/infrastructure/vpc.yaml
+++ b/infrastructure/vpc.yaml
@@ -41,6 +41,7 @@ Resources:
         Type: AWS::EC2::VPC
         Properties:
             CidrBlock: !Ref VpcCIDR
+            EnableDnsHostnames: true
             Tags: 
                 - Key: Name 
                   Value: !Ref EnvironmentName


### PR DESCRIPTION
It's generally valuable for hosts to be given DNS hostnames, so this would be a good default for a VPC template.