### PR TITLE
bugfixes

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -338,4 +338,4 @@ Outputs:
 
     ECSServiceAutoScalingRole:
         Description: A reference to ECS service auto scaling role
-        Value: !Ref ECSServiceAutoScalingRole
+        Value: !GetAtt ECSServiceAutoScalingRole.Arn

--- a/master.yaml
+++ b/master.yaml
@@ -80,7 +80,7 @@ Resources:
                 ProductServiceUrl: !Join [ "/", [ !GetAtt ALB.Outputs.LoadBalancerUrl, "products" ]]
                 Listener: !GetAtt ALB.Outputs.Listener 
                 Path: /
-                ECSServiceAutoScalingRoleARN: !GetAtt ECS.Outputs.ECSServiceAutoScalingRole.Arn
+                ECSServiceAutoScalingRoleARN: !GetAtt ECS.Outputs.ECSServiceAutoScalingRole
 
 
 Outputs:

--- a/services/website-service/service.yaml
+++ b/services/website-service/service.yaml
@@ -155,7 +155,7 @@ Resources:
                 - - service
                   - !Ref Cluster
                   - !GetAtt Service.Name
-            RoleARN: !GetAtt ECSServiceAutoScalingRoleARN
+            RoleARN: !Ref ECSServiceAutoScalingRoleARN
             ScalableDimension: ecs:service:DesiredCount
             ServiceNamespace: ecs
 


### PR DESCRIPTION
Fixed invalid IAM Role ARN Output from ECS-Cluster Stack which caused Website Service stack to fail creation

 	CREATE_FAILED 	AWS::CloudFormation::Stack 	WebsiteService
        Output 'ECSServiceAutoScalingRole.Arn' not found in stack 