### PR TITLE
Better CloudFormation validation output in tests

### DIFF
--- a/tests/validate-templates.sh
+++ b/tests/validate-templates.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 ERROR_COUNT=0; 
 
+echo "Validating AWS CloudFormation templates..."
+
 # Loop through the YAML templates in this repository
 for TEMPLATE in $(find . -name '*.yaml'); do 
 
     # Validate the template with CloudFormation
     ERRORS=$(aws cloudformation validate-template --template-body file://$TEMPLATE 2>&1 >/dev/null); 
-    
     if [ "$?" -gt "0" ]; then 
-
         ((ERROR_COUNT++));
-        echo "$TEMPLATE: $ERRORS";
+        echo "[fail] $TEMPLATE: $ERRORS";
+    else 
+        echo "[pass] $TEMPLATE";
     fi; 
     
 done; 


### PR DESCRIPTION
Example test output:

```
Validating AWS CloudFormation templates...
[fail] ./infrastructure/lifecyclehook.yaml:
An error occurred (ValidationError) when calling the ValidateTemplate operation: Template format error: Unrecognized parameter type: Stringgg
[pass] ./infrastructure/ecs-cluster.yaml
[pass] ./infrastructure/security-groups.yaml
[pass] ./infrastructure/load-balancers.yaml
[pass] ./infrastructure/vpc.yaml
[pass] ./services/product-service/service.yaml
[pass] ./services/website-service/service.yaml
[pass] ./master.yaml
1 template validation error(s)
```