### PR TITLE
LogConfiguration awslogs-group references LogGroup resource

### DIFF
--- a/services/product-service/service.yaml
+++ b/services/product-service/service.yaml
@@ -54,7 +54,7 @@ Resources:
                   LogConfiguration:
                     LogDriver: awslogs
                     Options:
-                        awslogs-group: CloudWatchLogsGroup
+                        awslogs-group: !Ref CloudWatchLogsGroup
                         awslogs-region: !Ref AWS::Region
     
     CloudWatchLogsGroup:

--- a/services/product-service/service.yaml
+++ b/services/product-service/service.yaml
@@ -54,7 +54,7 @@ Resources:
                   LogConfiguration:
                     LogDriver: awslogs
                     Options:
-                        awslogs-group: !Ref AWS::StackName
+                        awslogs-group: CloudWatchLogsGroup
                         awslogs-region: !Ref AWS::Region
     
     CloudWatchLogsGroup:

--- a/services/website-service/service.yaml
+++ b/services/website-service/service.yaml
@@ -71,7 +71,7 @@ Resources:
                   LogConfiguration:
                     LogDriver: awslogs
                     Options:
-                        awslogs-group: !Ref AWS::StackName
+                        awslogs-group: !Ref CloudWatchLogsGroup
                         awslogs-region: !Ref AWS::Region
 
     CloudWatchLogsGroup:


### PR DESCRIPTION
In the `AWS::ECS::TaskDefinition` `LogConfiguration` the `awslogs-group` was `!Ref AWS::StackName`. This happened to work because the `AWS::Logs::LogGroup` `LogGroupName` was also `!Ref AWS::StackName`.

This PR changes `awslogs-group` to reference the `AWS::Logs::LogGroup`, making it clearer to understand, more resilient to change, and establishes the right dependency tree and resource creation order in CloudFormation.