### PR TITLE
Added DependsOn condition

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -83,6 +83,7 @@ Resources:
             ClusterName: !Ref EnvironmentName
 
     ECSAutoScalingGroup:
+        DependsOn: ECSCluster
         Type: AWS::AutoScaling::AutoScalingGroup
         Properties:
             VPCZoneIdentifier: !Ref Subnets


### PR DESCRIPTION
This will fix the situation which demands ECS Cluster should come up and then autoscaling should register with it. Seen few race conditions situations while creation and deletion of CFN stack.