### PR TITLE
Unified CloudWatch Agent

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -81,7 +81,8 @@ Resources:
         "Fn::Base64": !Sub |
           #!/bin/bash
           yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-          yum install -y aws-cfn-bootstrap hibagent
+          yum install -y https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+          yum install -y aws-cfn-bootstrap hibagent 
           /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
           /opt/aws/bin/cfn-signal -e $? --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSAutoScalingGroup
           /usr/bin/enable-ec2-spot-hibernation
@@ -91,13 +92,15 @@ Resources:
         config:
           packages:
             yum:
-              awslogs: []
+              collectd: []
 
           commands:
             01_add_instance_to_cluster:
               command: !Sub echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
+            02_enable_cloudwatch_agent:
+              command: !Sub /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:${ECSCloudWatchParameter} -s
           files:
-            "/etc/cfn/cfn-hup.conf":
+            /etc/cfn/cfn-hup.conf:
               mode: 000400
               owner: root
               group: root
@@ -106,59 +109,12 @@ Resources:
                 stack=${AWS::StackId}
                 region=${AWS::Region}
 
-            "/etc/cfn/hooks.d/cfn-auto-reloader.conf":
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
               content: !Sub |
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.ECSLaunchConfiguration.Metadata.AWS::CloudFormation::Init
                 action=/opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
-
-            "/etc/awslogs/awscli.conf":
-              content: !Sub |
-                [plugins]
-                cwlogs = cwlogs
-                [default]
-                region = ${AWS::Region}
-
-            "/etc/awslogs/awslogs.conf":
-              content: !Sub |
-                [general]
-                state_file = /var/lib/awslogs/agent-state
-
-                [/var/log/dmesg]
-                file = /var/log/dmesg
-                log_group_name = ${ECSCluster}-/var/log/dmesg
-                log_stream_name = ${ECSCluster}
-
-                [/var/log/messages]
-                file = /var/log/messages
-                log_group_name = ${ECSCluster}-/var/log/messages
-                log_stream_name = ${ECSCluster}
-                datetime_format = %b %d %H:%M:%S
-
-                [/var/log/docker]
-                file = /var/log/docker
-                log_group_name = ${ECSCluster}-/var/log/docker
-                log_stream_name = ${ECSCluster}
-                datetime_format = %Y-%m-%dT%H:%M:%S.%f
-
-                [/var/log/ecs/ecs-init.log]
-                file = /var/log/ecs/ecs-init.log.*
-                log_group_name = ${ECSCluster}-/var/log/ecs/ecs-init.log
-                log_stream_name = ${ECSCluster}
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/ecs/ecs-agent.log]
-                file = /var/log/ecs/ecs-agent.log.*
-                log_group_name = ${ECSCluster}-/var/log/ecs/ecs-agent.log
-                log_stream_name = ${ECSCluster}
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
-
-                [/var/log/ecs/audit.log]
-                file = /var/log/ecs/audit.log.*
-                log_group_name = ${ECSCluster}-/var/log/ecs/audit.log
-                log_stream_name = ${ECSCluster}
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
 
           services:
             sysvinit:
@@ -168,12 +124,6 @@ Resources:
                 files:
                   - /etc/cfn/cfn-hup.conf
                   - /etc/cfn/hooks.d/cfn-auto-reloader.conf
-              awslogs:
-                enabled: true
-                ensureRunning: true
-                files:
-                  - /etc/awslogs/awslogs.conf
-                  - /etc/awslogs/awscli.conf
 
   # This IAM Role is attached to all of the ECS hosts. It is based on the default role
   # published here:
@@ -198,6 +148,9 @@ Resources:
                 }
             }]
         }
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyName: ecs-service
           PolicyDocument: |
@@ -212,46 +165,10 @@ Resources:
                         "ecs:RegisterContainerInstance",
                         "ecs:StartTelemetrySession",
                         "ecs:Submit*",
-                        "logs:CreateLogStream",
-                        "logs:PutLogEvents",
                         "ecr:BatchCheckLayerAvailability",
                         "ecr:BatchGetImage",
                         "ecr:GetDownloadUrlForLayer",
-                        "ecr:GetAuthorizationToken",
-                        "ssm:DescribeAssociation",
-                        "ssm:GetDeployablePatchSnapshotForInstance",
-                        "ssm:GetDocument",
-                        "ssm:GetManifest",
-                        "ssm:GetParameters",
-                        "ssm:ListAssociations",
-                        "ssm:ListInstanceAssociations",
-                        "ssm:PutInventory",
-                        "ssm:PutComplianceItems",
-                        "ssm:PutConfigurePackageResult",
-                        "ssm:UpdateAssociationStatus",
-                        "ssm:UpdateInstanceAssociationStatus",
-                        "ssm:UpdateInstanceInformation",
-                        "ec2messages:AcknowledgeMessage",
-                        "ec2messages:DeleteMessage",
-                        "ec2messages:FailMessage",
-                        "ec2messages:GetEndpoint",
-                        "ec2messages:GetMessages",
-                        "ec2messages:SendReply",
-                        "cloudwatch:PutMetricData",
-                        "ec2:DescribeInstanceStatus",
-                        "ds:CreateComputer",
-                        "ds:DescribeDirectories",
-                        "logs:CreateLogGroup",
-                        "logs:CreateLogStream",
-                        "logs:DescribeLogGroups",
-                        "logs:DescribeLogStreams",
-                        "logs:PutLogEvents",
-                        "s3:PutObject",
-                        "s3:GetObject",
-                        "s3:AbortMultipartUpload",
-                        "s3:ListMultipartUploadParts",
-                        "s3:ListBucket",
-                        "s3:ListBucketMultipartUploads"
+                        "ecr:GetAuthorizationToken"
                     ],
                     "Resource": "*"
                 }]
@@ -289,6 +206,92 @@ Resources:
                 - ecs:DescribeServices
                 - ecs:UpdateService
               Resource: "*"
+
+  ECSCloudWatchParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: ECS
+      Name: !Sub "AmazonCloudWatch-${ECSCluster}-ECS"
+      Type: String
+      Value: !Sub |
+        {
+          "logs": {
+            "force_flush_interval": 5,
+            "logs_collected": {
+              "files": {
+                "collect_list": [
+                  {
+                    "file_path": "/var/log/messages",
+                    "log_group_name": "${ECSCluster}-/var/log/messages",
+                    "log_stream_name": "{instance_id}",
+                    "timestamp_format": "%b %d %H:%M:%S"
+                  },
+                  {
+                    "file_path": "/var/log/dmesg",
+                    "log_group_name": "${ECSCluster}-/var/log/dmesg",
+                    "log_stream_name": "{instance_id}"
+                  },
+                  {
+                    "file_path": "/var/log/docker",
+                    "log_group_name": "${ECSCluster}-/var/log/docker",
+                    "log_stream_name": "{instance_id}",
+                    "timestamp_format": "%Y-%m-%dT%H:%M:%S.%f"
+                  },
+                  {
+                    "file_path": "/var/log/ecs/ecs-init.log",
+                    "log_group_name": "${ECSCluster}-/var/log/ecs/ecs-init.log",
+                    "log_stream_name": "{instance_id}",
+                    "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+                  },
+                  {
+                    "file_path": "/var/log/ecs/ecs-agent.log.*",
+                    "log_group_name": "${ECSCluster}-/var/log/ecs/ecs-agent.log",
+                    "log_stream_name": "{instance_id}",
+                    "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+                  },
+                  {
+                    "file_path": "/var/log/ecs/audit.log",
+                    "log_group_name": "${ECSCluster}-/var/log/ecs/audit.log",
+                    "log_stream_name": "{instance_id}",
+                    "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+                  }
+                ]
+              }
+            }
+          },
+          "metrics": {
+            "append_dimensions": {
+              "AutoScalingGroupName": "${!aws:AutoScalingGroupName}",
+              "InstanceId": "${!aws:InstanceId}",
+              "InstanceType": "${!aws:InstanceType}"
+            },
+            "metrics_collected": {
+              "collectd": {
+                "metrics_aggregation_interval": 60
+              },
+              "disk": {
+                "measurement": [
+                  "used_percent"
+                ],
+                "metrics_collection_interval": 60,
+                "resources": [
+                  "/"
+                ]
+              },
+              "mem": {
+                "measurement": [
+                  "mem_used_percent"
+                ],
+                "metrics_collection_interval": 60
+              },
+              "statsd": {
+                "metrics_aggregation_interval": 60,
+                "metrics_collection_interval": 10,
+                "service_address": ":8125"
+              }
+            }
+          }
+        }
 
 Outputs:
   Cluster:

--- a/services/product-service/service.yaml
+++ b/services/product-service/service.yaml
@@ -123,9 +123,9 @@ Resources:
                         "elasticloadbalancing:DeregisterTargets",
                         "elasticloadbalancing:DescribeTargetGroups",
                         "elasticloadbalancing:DescribeTargetHealth",
-                        "elasticloadbalancing:RegisterTargets",
+                        "elasticloadbalancing:RegisterTargets"
                       ],
-                    "Resource": "*",
-                  },
-                ],
+                    "Resource": "*"
+                  }
+                ]
             }

--- a/services/website-service/service.yaml
+++ b/services/website-service/service.yaml
@@ -140,11 +140,11 @@ Resources:
                         "elasticloadbalancing:DeregisterTargets",
                         "elasticloadbalancing:DescribeTargetGroups",
                         "elasticloadbalancing:DescribeTargetHealth",
-                        "elasticloadbalancing:RegisterTargets",
+                        "elasticloadbalancing:RegisterTargets"
                       ],
-                    "Resource": "*",
-                  },
-                ],
+                    "Resource": "*"
+                  }
+                ]
             }
 
   ServiceScalableTarget:


### PR DESCRIPTION
- Added CloudWatch Unified Agent
- Removed CloudWatch Logs (only) Agent
- Added SSM and CWAgent managed policies to ECS Role
- Added ECS CloudWatch Parameter
- Default Logs: unchanged from previous CloudWatch Logs Agent implementation
- Default Metrics: Root Volume % used, Memory % Used
- Removed some extra commas in the two service.yaml's