### PR TITLE
Update lifecyclehook.yaml

### DIFF
--- a/infrastructure/lifecyclehook.yaml
+++ b/infrastructure/lifecyclehook.yaml
@@ -141,5 +141,5 @@ Resources:
       Role: !GetAtt
         - LambdaExecutionRole
         - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 10


### PR DESCRIPTION
Setting the runtime to Python 3.9 as Python 3.6 is no longer supported in a Lambda function.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
